### PR TITLE
Cloudwatch add status check alarms

### DIFF
--- a/contrib/terraform/aws/00-create-infrastructure.tf
+++ b/contrib/terraform/aws/00-create-infrastructure.tf
@@ -443,7 +443,7 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-master" {
 
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-data-minions-1" {
     count = "${var.numDataNodes}"
-    alarm_name = "terraform-status-check-data-minions"
+    alarm_name = "terraform-status-check-data-minions-${count.index}"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
     metric_name = "StatusCheckFailed"
@@ -460,7 +460,7 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-data-minions-1" {
 
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-minions-1" {
     count = "${var.numNodes}"
-    alarm_name = "terraform-status-check-minions"
+    alarm_name = "terraform-status-check-minions-${count.index}"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
     metric_name = "StatusCheckFailed"
@@ -477,7 +477,7 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-minions-1" {
 
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-master-1" {
     count = "${var.numControllers}"
-    alarm_name = "terraform-status-check-master"
+    alarm_name = "terraform-status-check-master-${count.index}"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
     metric_name = "StatusCheckFailed"

--- a/contrib/terraform/aws/00-create-infrastructure.tf
+++ b/contrib/terraform/aws/00-create-infrastructure.tf
@@ -430,6 +430,59 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-master" {
     alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
 }
 
+resource "aws_cloudwatch_metric_alarm" "metric-alarm-data-minions-1" {
+    count = "${var.numDataNodes}"
+    alarm_name = "terraform-status-check-data-minions"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
+    metric_name = "StatusCheckFailed"
+    namespace = "AWS/EC2"
+    period =  "${var.cpu_utilization_alarm_period}"
+    statistic = "Average"
+    threshold = "1"
+    dimensions = {
+        InstanceId = "${element(aws_instance.data-minion.*.id, count.index)}"
+    }
+    alarm_description = "This metric monitor ec2 instance status check"
+    alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "metric-alarm-minions-1" {
+    count = "${var.numNodes}"
+    alarm_name = "terraform-status-check-minions"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
+    metric_name = "StatusCheckFailed"
+    namespace = "AWS/EC2"
+    period =  "${var.cpu_utilization_alarm_period}"
+    statistic = "Average"
+    threshold =  "1"
+    dimensions = {
+        InstanceId = "${element(aws_instance.minion.*.id, count.index)}"
+    }
+    alarm_description = "This metric monitor ec2 instance status check"
+    alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "metric-alarm-master-1" {
+    count = "${var.numControllers}"
+    alarm_name = "terraform-status-check-master"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
+    metric_name = "StatusCheckFailed"
+    namespace = "AWS/EC2"
+    period =  "${var.cpu_utilization_alarm_period}"
+    statistic = "Average"
+    threshold =  "1"
+    dimensions = {
+        InstanceId = "${element(aws_instance.master.*.id, count.index)}"
+    }
+    alarm_description = "This metric monitor ec2 instance status check"
+    alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
+}
+
+
+
 output "kubernetes_master_profile" {
   value = "${aws_iam_instance_profile.kubernetes_master_profile.id}"
 }

--- a/contrib/terraform/aws/00-create-infrastructure.tf
+++ b/contrib/terraform/aws/00-create-infrastructure.tf
@@ -492,6 +492,24 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-master-1" {
     alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
 }
 
+resource "aws_cloudwatch_metric_alarm" "metric-alarm-etcd-1" {
+    count = "${var.numEtcd}"
+    alarm_name = "terraform-cpu-utilization-etcd-${count.index}"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods =  "${var.cpu_utilization_alarm_evaluation_period}"
+    metric_name = "StatusCheckFailed"
+    namespace = "AWS/EC2"
+    period =  "${var.cpu_utilization_alarm_period}"
+    statistic = "Average"
+    threshold =  "1"
+    dimensions = {
+        InstanceId = "${element(aws_instance.etcd.*.id, count.index)}"
+    }
+    alarm_description = "This metric monitor ec2 instance status check"
+    alarm_actions = ["${aws_sns_topic.alarm_sns.arn}"]
+}
+
+
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-etcd" {
     count = "${var.numEtcd}"
     alarm_name = "terraform-cpu-utilization-etcd-${count.index}"


### PR DESCRIPTION
@npateriya 
added status check alarm for ec2 instances. Also created subscription on aws dashboard for emailing to devnet-cloud-engineering@cisco.com

Haven't tested it though. So let me know if you face issues.